### PR TITLE
build with protobuf@3.1

### DIFF
--- a/Formula/snips-asr-google.rb
+++ b/Formula/snips-asr-google.rb
@@ -16,7 +16,7 @@ class SnipsAsrGoogle < Formula
 
   option "with-debug", "Build with debug support"
 
-  depends_on "protobuf" => :build
+  depends_on "protobuf@3.1" => :build
   depends_on "rust" => :build
   depends_on "snips-platform-common"
 


### PR DESCRIPTION
use protobuf@3.1 as protobuf@3.7 does not compile

```
/bin/sh ../libtool  --tag=CXX   --mode=link clang++ -Qunused-arguments -pthread -DHAVE_PTHREAD=1 -DHAVE_ZLIB=1 -Wall -Wno-sign-compare  -DNDEBUG -Qunused-arguments -pthread  -o zcgzip google/protobuf/testing/zcgzip.o  libprotobuf.la -lz 
error: invalid integral value 'g' in '-Og'
error: invalid integral value 'g' in '-Og'
```