### PR TITLE
snips-watch.rb depends on portaudio

### DIFF
--- a/Formula/snips-watch.rb
+++ b/Formula/snips-watch.rb
@@ -17,7 +17,9 @@ class SnipsWatch < Formula
   option "with-debug", "Build with debug support"
   option "without-completion", "bash, zsh and fish completion will not be installed"
 
+  depends_on "pkg-config" => :build
   depends_on "rust" => :build
+  depends_on "portaudio"
 
   def install
     target_dir = build.with?("debug") ? "target/debug" : "target/release"


### PR DESCRIPTION
snips-watch depends_on "portaudio" because of the new feature "listening to audio frames"